### PR TITLE
SCHED-1501: Build NCCL Inspector for NCCL 2.30

### DIFF
--- a/.github/workflows/nccl_inspector.yml
+++ b/.github/workflows/nccl_inspector.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   build:
-    name: Arch ${{ matrix.arch }} / nccl ${{ matrix.nccl_version }} / cuda ${{ matrix.cuda_version }}
+    name: Arch ${{ matrix.arch }} / cuda ${{ matrix.cuda_version }} / nccl ${{ matrix.nccl_version }}
     permissions:
       contents: read
     runs-on: ${{ matrix.runner }}
@@ -16,98 +16,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nccl_version:
-          - '2.28.3-1'
-          - '2.28.7-1'
-          - '2.28.9-1'
-          - '2.29.2-1'
-          - '2.29.3-1'
-          - '2.29.7-1'
-        cuda_version: ['12.9.0', '13.0.2']
         arch: ['amd64', 'arm64']
+        cuda_version: ['12.9.0', '13.0.2']
+        nccl_version: ['2.30.3-1']
 
         include:
           - distribution: 'ubuntu24.04'
-          - nccl_repo_owner: 'NVIDIA'
-          - nccl_version_major: '2'
-          - nccl_version_release: '1'
+
           - arch: 'amd64'
             platform: 'linux/amd64'
             runner: 'ubuntu-24.04'
-            nccl_arch: 'x86_64'
+            lib_arch: 'x86_64'
           - arch: 'arm64'
             platform: 'linux/arm64'
             runner: 'ubuntu-24.04-arm'
-            nccl_arch: 'aarch64'
+            lib_arch: 'aarch64'
+
           - cuda_version: '12.9.0'
             nccl_cuda_version: '12.9'
           - cuda_version: '13.0.2'
             nccl_cuda_version: '13.0'
 
-          - nccl_version: '2.28.3-1'
-            path_to_inspector: 'ext-profiler/inspector'
-          - nccl_version: '2.28.7-1'
-            path_to_inspector: 'ext-profiler/inspector'
-          - nccl_version: '2.28.9-1'
-            path_to_inspector: 'ext-profiler/inspector'
-          - nccl_version: '2.29.2-1'
-            path_to_inspector: 'ext-profiler/inspector'
-          - nccl_version: '2.29.3-1'
-            path_to_inspector: 'ext-profiler/inspector'
-          - nccl_version: '2.29.7-1'
-            path_to_inspector: 'plugins/profiler/inspector'
-
-          - nccl_version: '2.29.7-1-fix-init-cpu-affinity'
-            nccl_repo_owner: 'rdjjke'
-            cuda_version: '12.9.0'
-            nccl_cuda_version: '12.9'
-            distribution: 'ubuntu24.04'
-            nccl_version_major: '2'
-            nccl_version_release: '1'
-            arch: 'amd64'
-            platform: 'linux/amd64'
-            runner: 'ubuntu-24.04'
-            nccl_arch: 'x86_64'
-            path_to_inspector: 'plugins/profiler/inspector'
-
-          - nccl_version: '2.29.7-1-fix-init-cpu-affinity'
-            nccl_repo_owner: 'rdjjke'
-            cuda_version: '12.9.0'
-            nccl_cuda_version: '12.9'
-            distribution: 'ubuntu24.04'
-            nccl_version_major: '2'
-            nccl_version_release: '1'
-            arch: 'arm64'
-            platform: 'linux/arm64'
-            runner: 'ubuntu-24.04-arm'
-            nccl_arch: 'aarch64'
-            path_to_inspector: 'plugins/profiler/inspector'
-
-          - nccl_version: '2.29.7-1-fix-init-cpu-affinity'
-            nccl_repo_owner: 'rdjjke'
-            cuda_version: '13.0.2'
-            nccl_cuda_version: '13.0'
-            distribution: 'ubuntu24.04'
-            nccl_version_major: '2'
-            nccl_version_release: '1'
-            arch: 'amd64'
-            platform: 'linux/amd64'
-            runner: 'ubuntu-24.04'
-            nccl_arch: 'x86_64'
-            path_to_inspector: 'plugins/profiler/inspector'
-
-          - nccl_version: '2.29.7-1-fix-init-cpu-affinity'
-            nccl_repo_owner: 'rdjjke'
-            cuda_version: '13.0.2'
-            nccl_cuda_version: '13.0'
-            distribution: 'ubuntu24.04'
-            nccl_version_major: '2'
-            nccl_version_release: '1'
-            arch: 'arm64'
-            platform: 'linux/arm64'
-            runner: 'ubuntu-24.04-arm'
-            nccl_arch: 'aarch64'
-            path_to_inspector: 'plugins/profiler/inspector'
+          - nccl_repo_owner: 'NVIDIA'
+          - nccl_version_major: '2'
+          - nccl_version_release: '1'
+          - nccl_path_to_inspector: 'plugins/profiler/inspector'
 
     steps:
       - name: Checkout repository
@@ -125,22 +58,23 @@ jobs:
           platforms: ${{ matrix.platform }}
           load: true
           build-args: |
+            ARCH=${{ matrix.arch }}
+            CUDA_VERSION=${{ matrix.cuda_version }}
+            LIB_ARCH=${{ matrix.lib_arch }}
             NCCL_REPO_OWNER=${{ matrix.nccl_repo_owner }}
             NCCL_VERSION=${{ matrix.nccl_version }}
             NCCL_VERSION_MAJOR=${{ matrix.nccl_version_major }}
             NCCL_VERSION_RELEASE=${{ matrix.nccl_version_release }}
-            NCCL_ARCH=${{ matrix.nccl_arch }}
             NCCL_CUDA_VERSION=${{ matrix.nccl_cuda_version }}
-            CUDA_VERSION=${{ matrix.cuda_version }}
-            PATH_TO_INSPECTOR=${{ matrix.path_to_inspector }}
+            NCCL_PATH_TO_INSPECTOR=${{ matrix.nccl_path_to_inspector }}
 
       - name: Create output directory
-        run: mkdir -p output/debs
+        run: mkdir -p artifacts
 
       - name: Run Docker container and copy files
         run: |
           container_id=$(docker create nccl_inspector_builder:nccl_${{ matrix.nccl_version }}_cuda_${{ matrix.cuda_version }}_${{ matrix.distribution }}_${{ matrix.nccl_version_release }})
-          docker cp ${container_id}:/debs/. ./output/debs/
+          docker cp ${container_id}:/artifacts/. ./artifacts/
           docker rm ${container_id}
 
       - name: Normalize platform for artifact names
@@ -150,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: debs-nccl-inspector-${{ matrix.nccl_version }}-cuda-${{ matrix.nccl_cuda_version }}-${{ matrix.distribution }}-${{ matrix.nccl_version_release }}-${{ env.PLATFORM_SAFE }}
-          path: output/debs/*.deb
+          path: artifacts/*.deb
           if-no-files-found: error
           overwrite: 'true'
           retention-days: 7
@@ -165,40 +99,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nccl_version:
-          - '2.28.3-1'
-          - '2.28.7-1'
-          - '2.28.9-1'
-          - '2.29.2-1'
-          - '2.29.3-1'
-          - '2.29.7-1'
-          - '2.29.7-1-fix-init-cpu-affinity'
         cuda_version: ['12.9', '13.0']
+        nccl_version: ['2.30.3-1']
         include:
           - distribution: 'ubuntu24.04'
+          - nccl_repo_owner: 'NVIDIA'
           - nccl_version_release: '1'
-
-          - nccl_version: '2.28.3-1'
-            nccl_repo_owner: 'NVIDIA'
-            path_to_inspector: 'ext-profiler/inspector'
-          - nccl_version: '2.28.7-1'
-            nccl_repo_owner: 'NVIDIA'
-            path_to_inspector: 'ext-profiler/inspector'
-          - nccl_version: '2.28.9-1'
-            nccl_repo_owner: 'NVIDIA'
-            path_to_inspector: 'ext-profiler/inspector'
-          - nccl_version: '2.29.2-1'
-            nccl_repo_owner: 'NVIDIA'
-            path_to_inspector: 'ext-profiler/inspector'
-          - nccl_version: '2.29.3-1'
-            nccl_repo_owner: 'NVIDIA'
-            path_to_inspector: 'ext-profiler/inspector'
-          - nccl_version: '2.29.7-1'
-            nccl_repo_owner: 'NVIDIA'
-            path_to_inspector: 'plugins/profiler/inspector'
-          - nccl_version: '2.29.7-1-fix-init-cpu-affinity'
-            nccl_repo_owner: 'rdjjke'
-            path_to_inspector: 'plugins/profiler/inspector'
+          - nccl_path_to_inspector: 'plugins/profiler/inspector'
 
     concurrency:
       group: release-nccl-inspector-${{ matrix.nccl_version }}-cuda-${{ matrix.cuda_version }}-${{ matrix.distribution }}-${{ matrix.nccl_version_release }}
@@ -237,7 +144,7 @@ jobs:
           tag_name: nccl-inspector-${{ matrix.nccl_version }}-cuda-${{ matrix.cuda_version }}-${{ matrix.distribution }}-${{ matrix.nccl_version_release }}
           name: NCCL Inspector v${{ matrix.nccl_version }}+cuda${{ matrix.cuda_version }}-${{ matrix.nccl_version_release }}_${{ matrix.distribution }}
           body: |
-            [NCCL Inspector plugin](https://github.com/${{ matrix.nccl_repo_owner }}/nccl/tree/v${{ matrix.nccl_version }}/${{ matrix.path_to_inspector }})
+            [NCCL Inspector plugin](https://github.com/${{ matrix.nccl_repo_owner }}/nccl/tree/v${{ matrix.nccl_version }}/${{ matrix.nccl_path_to_inspector }})
             
             | NCCL version | CUDA version | Distribution | Deb version |
             | :--- | :--- | :---: | ---: |
@@ -246,4 +153,4 @@ jobs:
           prerelease: false
           fail_on_unmatched_files: true
           files: |
-            artifacts/**/*.deb
+            artifacts/*.deb

--- a/nccl-inspector/Dockerfile
+++ b/nccl-inspector/Dockerfile
@@ -15,16 +15,17 @@ ARG NCCL_REPO_OWNER
 ARG NCCL_VERSION
 ARG NCCL_VERSION_MAJOR
 ARG NCCL_VERSION_RELEASE
-ARG NCCL_ARCH
 ARG NCCL_CUDA_VERSION
-ARG PATH_TO_INSPECTOR
+ARG NCCL_PATH_TO_INSPECTOR
+ARG ARCH
+ARG LIB_ARCH
 
 COPY nccl-inspector/config/ /usr/src/nccl-inspector
 
 # Build shared library
 RUN cd /usr/src && \
     git clone --branch v${NCCL_VERSION} --depth 1 https://github.com/${NCCL_REPO_OWNER}/nccl && \
-    cd nccl/${PATH_TO_INSPECTOR} && \
+    cd nccl/${NCCL_PATH_TO_INSPECTOR} && \
     make && \
     ls -lah *.so && \
     mv *.so /usr/src/nccl-inspector && \
@@ -43,5 +44,5 @@ RUN mkdir out && \
     ls -lah ./out/*.deb
 
 FROM cr.eu-north1.nebius.cloud/soperator/busybox
-COPY --from=builder /usr/src/nccl-inspector/out /debs
+COPY --from=builder /usr/src/nccl-inspector/out /artifacts
 CMD ["true"]

--- a/nccl-inspector/config/nfpm.yaml
+++ b/nccl-inspector/config/nfpm.yaml
@@ -1,6 +1,6 @@
 name: &pkg libnccl-profiler-inspector
 
-arch: ${NCCL_ARCH}
+arch: ${ARCH}
 platform: linux
 
 version: ${NCCL_VERSION}+cuda${NCCL_CUDA_VERSION}
@@ -30,16 +30,16 @@ suggests:
 
 contents:
   - src: libnccl-profiler-inspector.so
-    dst: /usr/lib/${NCCL_ARCH}-linux-gnu/libnccl-profiler-inspector.so.${NCCL_VERSION}
+    dst: /usr/lib/${LIB_ARCH}-linux-gnu/libnccl-profiler-inspector.so.${NCCL_VERSION}
     expand: true
 
   - src: libnccl-profiler-inspector.so.${NCCL_VERSION}
-    dst: /usr/lib/${NCCL_ARCH}-linux-gnu/libnccl-profiler-inspector.so.2
+    dst: /usr/lib/${LIB_ARCH}-linux-gnu/libnccl-profiler-inspector.so.2
     type: symlink
     expand: true
 
   - src: libnccl-profiler-inspector.so.2
-    dst: /usr/lib/${NCCL_ARCH}-linux-gnu/libnccl-profiler-inspector.so
+    dst: /usr/lib/${LIB_ARCH}-linux-gnu/libnccl-profiler-inspector.so
     type: symlink
     expand: true
 


### PR DESCRIPTION
### What has been done

- Removed released versions
- Added latest NCCL 2.30.3
- ARCH management simplified