### PR TITLE
SCHED-1615 Bump pyxis to 0.24.0

### DIFF
--- a/.github/workflows/pyxis.yml
+++ b/.github/workflows/pyxis.yml
@@ -22,7 +22,7 @@ jobs:
         enroot:
           - version: 4.1.2
         pyxis:
-          - version: 0.23.0
+          - version: 0.24.0
         distribution:
           - ubuntu24.04
         platform:
@@ -96,7 +96,7 @@ jobs:
         enroot:
           - version: 4.1.2
         pyxis:
-          - version: 0.23.0
+          - version: 0.24.0
         distribution:
           - ubuntu24.04
 


### PR DESCRIPTION
In order to support direct squashfuse startup we need to bump pyxis to 0.24.0+ https://github.com/NVIDIA/pyxis/commit/8d8fae8ea8191d261f0b90ac471ddd54aca4287f