### PR TITLE
GPU-2246 build libnccl 2.31.2 for cuda13.0

### DIFF
--- a/.github/workflows/nccl.yml
+++ b/.github/workflows/nccl.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         arch: [ 'amd64', 'arm64' ]
         cuda_version: [ '13.0.2' ]
-        nccl_version: [ '2.30.7-1' ]
+        nccl_version: [ '2.31.2-1' ]
         distribution: [ 'ubuntu24.04' ]
 
         include:
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - nccl_version: 2.30.7-1
+          - nccl_version: 2.31.2-1
             cuda_version: 13.0.2
             distribution: ubuntu24.04
 

--- a/.github/workflows/nccl_inspector.yml
+++ b/.github/workflows/nccl_inspector.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         arch: ['amd64', 'arm64']
         cuda_version: ['13.0.2']
-        nccl_version: ['2.30.7-1']
+        nccl_version: ['2.31.2-1']
         distribution: [ 'ubuntu24.04' ]
 
         include:
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda_version: [ '13.0' ]
-        nccl_version: [ '2.30.7-1' ]
+        nccl_version: [ '2.31.2-1' ]
         include:
           - distribution: 'ubuntu24.04'
           - nccl_repo_owner: 'NVIDIA'

--- a/nccl/Dockerfile
+++ b/nccl/Dockerfile
@@ -23,8 +23,8 @@ RUN cd /usr/src && \
 ################################################################
 # RESULT
 ################################################################
-# libnccl2_2.30.7-1+cuda13.0_amd64.deb
-# libnccl-dev_2.30.7-1-1+cuda13.0_amd64.deb
+# libnccl2_2.31.2-1+cuda13.0_amd64.deb
+# libnccl-dev_2.31.2-1-1+cuda13.0_amd64.deb
 
 # Move deb files
 RUN mkdir /usr/src/debs && \


### PR DESCRIPTION
Bump the nccl.yml workflow matrix 2.30.7-1 -> 2.31.2-1 (cuda 13.0.2, ubuntu24.04, amd64+arm64).